### PR TITLE
SC3215 Fix Banner Start & End Dates Display Bug

### DIFF
--- a/src/class-extended-cpt-admin.php
+++ b/src/class-extended-cpt-admin.php
@@ -917,6 +917,13 @@ ICONCSS;
 			foreach ( $vals as $val ) {
 				$val_time = strtotime( $val );
 
+				try {
+					new DateTime( '@' . $val );
+					$val_time = strtotime( '@' . $val );
+				} catch ( Exception $e ) {
+					$val_time = strtotime( $val );
+				}
+
 				if ( $val_time ) {
 					$val = $val_time;
 				}


### PR DESCRIPTION
Fixes this display bug in our fork of Extended CPTs so that we can use it for the time being, while down the line we can update to the most recent version of Extended CPTs which will hopefully have this fix included in it.


|**Before**|**After**|
|---|---|
|![before](http://ggwicz-dropshare.s3.amazonaws.com/sc3215-before.png)|![after](http://ggwicz-dropshare.s3.amazonaws.com/sc3215-after.png)|